### PR TITLE
Refactor request handling, enums, and class naming for consistency

### DIFF
--- a/CHANGELOG-6.0.md
+++ b/CHANGELOG-6.0.md
@@ -1,0 +1,323 @@
+# Changelog - Version 6.0
+
+## Overview
+
+Version 6.0 represents a major release with significant improvements in error handling, type safety, authentication,
+PSR-7 compatibility, and PHP 8.4 support. This release removes the dependency on `filp/whoops` in favor of a custom
+error handling implementation and introduces several new features for route-level security and content processing.
+
+---
+
+## New Features
+
+### Authentication and Authorization
+
+- **RequireAuthenticated Attribute**: New route-level attribute for enforcing authentication requirements on specific
+  endpoints
+- **RequireRole Attribute**: New route-level attribute for role-based access control with support for:
+    - Extracting roles from arrays
+    - Extracting roles from objects
+    - Enhanced validation logic
+
+### PSR-7 Adapters
+
+- **PSR-7 Compatibility**: New adapter implementation for `HttpRequest` and `HttpResponse` to work seamlessly with PSR-7
+  compliant libraries
+- Full support for PSR-7 HTTP message interfaces
+- Comprehensive test coverage for PSR-7 adapters
+
+### Content Processing
+
+- **CSV Output Processor**: New output processor for generating CSV responses from API endpoints
+- **Plain Text Processor**: Support for plain text responses in addition to JSON and XML
+- **Strict Mode**: Enhanced output processor validation with strict mode support for MIME type checking
+- **Content Negotiation**: Improved content negotiation capabilities with better MIME type handling
+
+### Development Tools
+
+- **Docker-based Development Setup**: Complete Docker development environment with `docker-compose.yml`
+- **Enhanced Testing**: Mock testing capabilities with improved `MockRequestHandler`
+- **Gitpod Support**: Pre-configured `.gitpod.yml` for cloud-based development
+
+### Documentation
+
+- Comprehensive new documentation sections:
+    - File Uploads guide
+    - PSR-7 Adapters guide
+    - Mock Testing guide
+    - Route Metadata guide
+    - Content Negotiation guide
+    - Custom HTTP Status Codes guide
+    - CSV Endpoint Example
+    - Enhanced middleware documentation (CORS, Static Server, JWT)
+
+---
+
+## Improvements
+
+### Type Safety and Code Quality
+
+- Enhanced type safety across the entire codebase with nullable type hints
+- Improved null handling in request processing and output processors
+- Better type checks and casting for request handling, routes, and middleware
+- Refined Psalm configuration with improved annotations
+- Added Psalm cache configuration for faster static analysis
+
+### Error Handling
+
+- Custom error handling system replacing `filp/whoops`
+- Better exception hierarchy with `HttpResponseException` base class
+- Enhanced exception metadata support
+- Improved error handler cleanup in testing
+- More detailed error messages with configurable verbosity
+
+### Header Handling
+
+- Normalized header handling with case-insensitive comparisons
+- Enhanced header updates across different sources
+- Better content-type override capabilities
+
+### Testing
+
+- Stricter PHPUnit failure conditions
+- Enhanced test coverage for authentication and authorization
+- Route-level tests for new attributes
+- Better test organization and assertions
+
+### Workflow and CI/CD
+
+- Updated GitHub Actions workflow to use privileged containers
+- Latest checkout action version support
+- Enhanced PHPUnit workflow configuration
+
+---
+
+## Breaking Changes
+
+| Area                 | Before (5.x)                                                                                                                                  | After (6.0)                                                                                                                                   | Description                                                              |
+|----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------|
+| **PHP Version**      | `>=8.1 <8.4`                                                                                                                                  | `>=8.3 <8.6`                                                                                                                                  | Minimum PHP version raised to 8.3, added support for 8.4 and 8.5         |
+| **Dependencies**     | `byjg/serializer: ^5.0`<br>`byjg/singleton-pattern: ^5.0`<br>`byjg/cache-engine: ^5.0`<br>`byjg/webrequest: ^5.0`<br>`byjg/jwt-wrapper: ^5.0` | `byjg/serializer: ^6.0`<br>`byjg/singleton-pattern: ^6.0`<br>`byjg/cache-engine: ^6.0`<br>`byjg/webrequest: ^6.0`<br>`byjg/jwt-wrapper: ^6.0` | All ByJG dependencies updated to version 6.0                             |
+| **Error Handler**    | Used `filp/whoops` library                                                                                                                    | Custom built-in error handler                                                                                                                 | Removed dependency on `filp/whoops`; replaced with native error handling |
+| **ErrorHandler API** | `setHandler(Handler $handler)`                                                                                                                | `setOutputProcessor(OutputProcessorInterface $processor, HttpResponse $response, HttpRequest $request, bool $detailed = false)`               | Complete refactor of error handler initialization and configuration      |
+| **PHPUnit**          | `^5.7\|^7.4\|^9.6`                                                                                                                            | `^10.5\|^11.5`                                                                                                                                | Updated to modern PHPUnit versions only                                  |
+| **Psalm**            | `^5.9`                                                                                                                                        | `^5.9\|^6.13`                                                                                                                                 | Added support for Psalm 6.x                                              |
+| **PSR Dependencies** | PSR-7 not explicitly supported                                                                                                                | Added `psr/http-client: ^1.0`<br>`psr/http-factory: ^1.0\|^1.1`                                                                               | New PSR-7 support requires additional dependencies                       |
+
+---
+
+## Upgrade Path from 5.x to 6.0
+
+### Step 1: Update PHP Version
+
+Ensure you are running PHP 8.3 or higher:
+
+```bash
+php -v
+```
+
+If you're on PHP 8.1 or 8.2, upgrade your PHP installation before proceeding.
+
+### Step 2: Update Dependencies
+
+Update your `composer.json` to require version 6.0:
+
+```json
+{
+  "require": {
+    "byjg/restserver": "^6.0"
+  }
+}
+```
+
+Then run:
+
+```bash
+composer update byjg/restserver
+```
+
+This will automatically update all related ByJG dependencies to version 6.0.
+
+### Step 3: Remove Whoops Integration (If Customized)
+
+If you have custom error handlers using Whoops:
+
+**Before (5.x):**
+
+```php
+use ByJG\RestServer\ErrorHandler;
+use Whoops\Handler\PrettyPageHandler;
+
+$errorHandler = ErrorHandler::getInstance();
+$errorHandler->setHandler(new PrettyPageHandler());
+$errorHandler->register();
+```
+
+**After (6.0):**
+
+```php
+use ByJG\RestServer\ErrorHandler;
+use ByJG\RestServer\Application;
+
+// Error handling is now automatic and configured via HttpRequestHandler
+$server = new Application($logger);
+$server->withDetailedErrorHandler(); // Optional: for development
+$server->handle($routeList);
+```
+
+### Step 4: Update PHPUnit Configuration
+
+If you have PHPUnit tests, update your `phpunit.xml.dist`:
+
+**Before (5.x):**
+
+```xml
+
+<phpunit phpVersion="7.4.0"/>
+```
+
+**After (6.0):**
+
+```xml
+
+<phpunit phpVersion="8.3.0"/>
+```
+
+And update your `composer.json` dev dependencies:
+
+```json
+{
+  "require-dev": {
+    "phpunit/phpunit": "^10.5|^11.5"
+  }
+}
+```
+
+### Step 5: Review Custom Error Handlers
+
+If you implemented custom error handling:
+
+1. Review the new `ErrorHandler` API in `src/ErrorHandler.php`
+2. Update any custom error handler integrations to use the new `setOutputProcessor()` method
+3. Test error scenarios thoroughly
+
+### Step 6: Test Your Application
+
+Run your test suite:
+
+```bash
+composer test
+```
+
+Run static analysis:
+
+```bash
+composer psalm
+```
+
+### Step 7: Optional - Leverage New Features
+
+Consider adopting new features:
+
+1. **Authentication Attributes**: Replace custom authentication middleware with `#[RequireAuthenticated]` and
+   `#[RequireRole]` attributes
+2. **PSR-7 Adapters**: Use PSR-7 adapters if integrating with PSR-7 libraries
+3. **CSV Output**: Implement CSV endpoints using the new `CsvOutputProcessor`
+4. **Docker Development**: Use the provided `docker-compose.yml` for local development
+
+---
+
+## Migration Examples
+
+### Example 1: Error Handler Configuration
+
+**Before (5.x):**
+
+```php
+use ByJG\RestServer\ErrorHandler;
+use Whoops\Handler\JsonResponseHandler;
+
+$errorHandler = ErrorHandler::getInstance();
+$errorHandler->setHandler(new JsonResponseHandler());
+$errorHandler->register();
+
+$server = new HttpRequestHandler();
+$server->handle($routeList);
+```
+
+**After (6.0):**
+
+```php
+use ByJG\RestServer\Application;
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+
+$logger = new Logger('app');
+$logger->pushHandler(new StreamHandler('php://stderr', Logger::ERROR));
+
+$server = new Application($logger);
+// Error handling is automatic based on the output processor
+$server->handle($routeList);
+```
+
+### Example 2: Adding Authentication
+
+**New in 6.0:**
+
+```php
+use ByJG\RestServer\Attributes\RouteDefinition;
+use ByJG\RestServer\Attributes\RequireAuthenticated;
+use ByJG\RestServer\Attributes\RequireRole;
+
+class UserController
+{
+    #[RouteDefinition('/api/profile', method: 'GET')]
+    #[RequireAuthenticated]
+    public function getProfile()
+    {
+        // Only authenticated users can access
+    }
+
+    #[RouteDefinition('/api/admin', method: 'GET')]
+    #[RequireRole(['admin', 'superuser'])]
+    public function adminPanel()
+    {
+        // Only users with admin or superuser role can access
+    }
+}
+```
+
+### Example 3: CSV Output
+
+**New in 6.0:**
+
+```php
+use ByJG\RestServer\OutputProcessor\CsvOutputProcessor;
+
+$route->addRoute('/api/export', function() {
+    return [
+        ['name' => 'John', 'email' => 'john@example.com'],
+        ['name' => 'Jane', 'email' => 'jane@example.com'],
+    ];
+})
+->withOutputProcessor(CsvOutputProcessor::class);
+```
+
+---
+
+## Notes
+
+- The removal of `filp/whoops` reduces dependencies and gives more control over error handling
+- PHP 8.3 requirement enables use of modern PHP features and better performance
+- All ByJG 6.0 libraries are designed to work together - avoid mixing 5.x and 6.x versions
+- The new error handling system is more lightweight and better integrated with the output processor system
+- Enhanced type safety may reveal previously hidden type issues in your code - address these with proper type
+  declarations
+
+---
+
+## Contributors
+
+Thank you to all contributors who made this release possible!
+
+For detailed commit history, see: https://github.com/byjg/php-restserver/compare/5.0.3...6.0.0

--- a/docs/autogenerator-routes-openapi.md
+++ b/docs/autogenerator-routes-openapi.md
@@ -41,7 +41,7 @@ In that case the `operationId` will be generated automatically. The format will 
 vendor/bin/openapi -c operationid.hash=false src
 ```
 
-After you have the proper swagger.json just call the `HttpRequestHandler`
+After you have the proper swagger.json just call the `Server`
 and set automatic routes:
 
 ```php
@@ -49,9 +49,12 @@ and set automatic routes:
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
+use ByJG\RestServer\Server;
+use ByJG\RestServer\Route\OpenApiRouteList;
+
 $routeDefinition = new OpenApiRouteList(__DIR__ . '/swagger.json');
 
-$restServer = new HttpRequestHandler();
+$restServer = new Server();
 $restServer->handle($routeDefinition);
 ```
 

--- a/docs/content-negotiation.md
+++ b/docs/content-negotiation.md
@@ -53,7 +53,7 @@ RestServer automatically sets the appropriate `Content-Type` header based on the
 - `application/xml` for XML responses
 - Custom content types as defined by your output processors
 
-You can override this at runtime by adding your own `Content-Type` header. When you do so, `HttpRequestHandler`
+You can override this at runtime by adding your own `Content-Type` header. When you do so, `Server`
 will detect the header (`HttpResponse::addHeader('Content-Type', ...)`) and automatically re-initialize the matching
 output processor before the response is serialized. This makes it possible to start with an XML route and switch to JSON
 for a particular response (or vice-versa).
@@ -109,7 +109,7 @@ You can implement custom content negotiation logic:
 public function processRequest(HttpRequest $request, HttpResponse $response)
 {
     // Check for a specific format parameter
-    $format = $request->param('format');
+    $format = $request->query('format');
     
     if ($format === 'csv') {
         $response->addHeader('Content-Type', 'text/csv');

--- a/docs/csv-endpoint-example.md
+++ b/docs/csv-endpoint-example.md
@@ -23,8 +23,6 @@ First, create a custom output processor for CSV files:
 
 namespace ByJG\RestServer\OutputProcessor;
 
-use ByJG\RestServer\HttpResponse;
-use ByJG\RestServer\SerializationRuleEnum;
 use ByJG\Serializer\Formatter\FormatterInterface;
 
 class CsvOutputProcessor extends BaseOutputProcessor
@@ -140,9 +138,9 @@ class YourController
    $filename = 'user-data-' . $userId . '-' . date('Y-m-d') . '.csv';
    ```
 
-4. **Raw CSV content**: If you need to create the CSV content manually, use the Raw serialization rule:
+4. **Plain CSV content**: If you need to create the CSV content manually, use the Plain output mode:
    ```php
-   $response->getResponseBag()->setSerializationRule(SerializationRuleEnum::Raw);
+   $response->getResponseBody()->serializeAs(OutputMode::Plain);
    $csvContent = "id,name,email\n1,\"John Doe\",john@example.com\n2,\"Jane Smith\",jane@example.com";
    $response->write($csvContent);
    ```

--- a/docs/defining-route-names.md
+++ b/docs/defining-route-names.md
@@ -14,7 +14,7 @@ You can define route with constant and/or variable. For example:
 | `/myroute/{id:[0-9]+}`  | Matches /myroute + any number combination and set to ID    |
 
 All variables defined above will be available as a parameter. In the example above,
-if the route matches the "id" you can get using `$request->param('id');`
+if the route matches the "id" you can get using `$request->attributeString('id');`
 
 Creating the pattern:
 
@@ -25,7 +25,7 @@ Creating the pattern:
 all matches values can be obtained by
 
 ```php
-$this->getRequest()->param('variable');
+$this->getRequest()->attributeString('variable');
 ```
 
 ## Best Practices for Route Names

--- a/docs/error-handler.md
+++ b/docs/error-handler.md
@@ -10,7 +10,7 @@ formatted error messages according to the OutputProcessor defined in the route.
 ## How it works
 
 1. Each route has an OutputProcessor that will handle the output of the route. (See [OutputProcessor](outprocessor.md))
-2. Initialize the HttpRequestHandler (it will handle the request and call the route)
+2. Initialize the `Server` (it will handle the request and call the route)
 3. Once an exception is thrown, the OutputProcessor will call the ErrorHandler 
 to handle the exception and return a detailed message (debug, dev, etc) or a simple one suitable
 for production.
@@ -19,11 +19,11 @@ for production.
 
 ### Setting a Logger
 
-You can provide a PSR-3 compatible logger to the HttpRequestHandler when initializing it:
+You can provide a PSR-3 compatible logger to the `Server` when initializing it:
 
 ```php
 <?php
-use ByJG\RestServer\HttpRequestHandler;
+use ByJG\RestServer\Server;
 use Monolog\Logger;
 use Monolog\Handler\StreamHandler;
 
@@ -32,7 +32,7 @@ $logger = new Logger('app');
 $logger->pushHandler(new StreamHandler('path/to/your.log', Logger::WARNING));
 
 // Initialize with logger
-$server = new HttpRequestHandler($logger);
+$server = new Server($logger);
 $server->handle($routeList);
 ```
 
@@ -44,9 +44,9 @@ You can disable the error handler completely and handle the exceptions by yourse
 
 ```php
 <?php
-use ByJG\RestServer\HttpRequestHandler;
+use ByJG\RestServer\Server;
 
-$server = new HttpRequestHandler();
+$server = new Server();
 $server->withErrorHandlerDisabled(); // Disable the error handler completely
 try {
     $server->handle($routeList);
@@ -62,9 +62,9 @@ stack trace, etc.
 
 ```php
 <?php
-use ByJG\RestServer\HttpRequestHandler;
+use ByJG\RestServer\Server;
 
-$server = new HttpRequestHandler();
+$server = new Server();
 $server->withDetailedErrorHandler(); // Enable the detailed error handler, for debug purposes
 $server->handle($routeList);
 ```

--- a/docs/httprequest-httpresponse.md
+++ b/docs/httprequest-httpresponse.md
@@ -16,60 +16,80 @@ informations to the requester.
 
 ## HttpRequest
 
-| Method                             | Description                                                            |
-|------------------------------------|------------------------------------------------------------------------|
-| get($var, $default)                | Get a value passed in the query string or all values if $var is null   |
-| post($var, $default)               | Get a value passed by the POST Form or all values if $var is null      |
-| server($var, $default)             | Get a value passed in the Request Header or all values if $var is null |
-| session($var, $default)            | Get a value from session or all values if $var is null                 |
-| cookie($var, $default)             | Get a value from a cookie or all values if $var is null                |
-| request($var, $default)            | Get a value from the get() OR post() or all values if $var is null     |
-| param($var, $default)              | Get a parameter from URL routing or all values if $var is null         |
-| payload()                          | Get the raw data passed in the request body                            |
-| getRequestIp()                     | Get the request IP (even if behind a proxy)                            |
-| ip()                               | Static method to get the request IP                                    |
-| getUserAgent()                     | Get the user agent                                                     |
-| userAgent()                        | Static method to get the user agent                                    |
-| getServerName()                    | Get the server name                                                    |
-| getRequestServer($port, $protocol) | Get the request server name with optional port and protocol            |
-| getHeader($header)                 | Get a specific header value                                            |
-| getRequestPath()                   | Get the request path                                                   |
-| uploadedFiles()                    | Return an instance of the UploadedFiles class                          |
-| appendVars($array)                 | Append variables to the request                                        |
-| routeMethod()                      | Get the HTTP method used for the current route                         |
-| getRouteMetadata($key)             | Get route metadata by key or all metadata if no key is provided        |
-| setRouteMetadata($routeMetadata)   | Set route metadata                                                     |
+| Method                             | Description                                                                 |
+|------------------------------------|-----------------------------------------------------------------------------|
+| query($var, $default)              | Get a value from the query string ($_GET) or all values if $var is null     |
+| body($var, $default)               | Get a value from the request body ($_POST) or all values if $var is null    |
+| server($var, $default)             | Get a value from $_SERVER or all values if $var is null                     |
+| session($var, $default)            | Get a value from the session ($_SESSION) or all values if $var is null      |
+| cookie($var, $default)             | Get a value from the cookies ($_COOKIE) or all values if $var is null       |
+| input($var, $default)              | Get a value from any source (query, body, server, session, cookie merged)   |
+| attribute($var, $default)          | Get a value injected by middleware or the framework (not URL or HTTP input) |
+| payload()                          | Get the raw request body (php://input)                                      |
+| getRequestIp()                     | Get the client IP address (checks proxy headers before REMOTE_ADDR)         |
+| ip()                               | Static method to get the client IP                                          |
+| getUserAgent()                     | Get the user agent                                                          |
+| userAgent()                        | Static method to get the user agent                                         |
+| getServerName()                    | Get the server name                                                         |
+| getRequestServer($port, $protocol) | Get the server name, optionally with port and/or protocol                   |
+| getHeader($header)                 | Get a specific request header value                                         |
+| getRequestPath()                   | Get the request path                                                        |
+| uploadedFiles()                    | Return an instance of the UploadedFiles class                               |
+| addAttributes($array)              | Bulk-add values to the attribute bag (middleware/framework use)             |
+| routeMethod()                      | Get the HTTP method used for the current route                              |
+| getRouteMetadata($key)             | Get route metadata by key or all metadata if no key is provided             |
+| setRouteMetadata($routeMetadata)   | Set route metadata                                                          |
+
+### Typed getters
+
+Each source also has typed variants that always return `?string` or `?array`:
+
+| Method                          | Source                                           |
+|---------------------------------|--------------------------------------------------|
+| queryString($key, $default)     | $_GET                                            |
+| queryArray($key, $default)      | $_GET                                            |
+| bodyString($key, $default)      | $_POST                                           |
+| bodyArray($key, $default)       | $_POST                                           |
+| serverString($key, $default)    | $_SERVER                                         |
+| cookieString($key, $default)    | $_COOKIE                                         |
+| sessionString($key, $default)   | $_SESSION                                        |
+| attributeString($key, $default) | attribute bag (route params + middleware values) |
+| inputString($key, $default)     | any source                                       |
 
 Example:
 
 ```php
 function ($response, $request) {
 
-    // Get a value passed in the query string
+    // Get a value from the query string
     // http://localhost/?myvar=123
-    $request->get('myvar');
-    
-    // Get a value passed by the POST Form
+    $request->query('myvar');
+
+    // Typed variant — guaranteed string or null
+    $myvar = $request->queryString('myvar');
+
+    // Get a value from the POST body
     // <form method="post"><input type="text" name="myvar" value="123" /></form>
-    $request->post('myvar');
-    
-    // Get a value passed in the Request Header (eg. HTTP_REFERER)
-    // http://localhost/?myvar=123
+    $request->body('myvar');
+
+    // Get a value from $_SERVER (eg. HTTP_REFERER)
     $request->server('HTTP_REFERER');
-    
-    // Get a payload passed in the request body
+
+    // Get the raw request body
     // {"myvar": 123}
-    $json = json_decode($request->payload('myvar'));
-    
-    // Get a route parameter (from URL)
-    // Route: /user/{id} -> URL: /user/123
-    $userId = $request->param('id');
-    
+    $json = json_decode($request->payload());
+
+    // Get a URL route placeholder (Route: /user/{id} -> URL: /user/123)
+    $userId = $request->attributeString('id');
+
+    // Get a middleware-injected attribute value
+    $jwtSub = $request->attributeString('jwt.sub');
+
     // Get information about the request
     $ip = $request->getRequestIp();
     $server = $request->getRequestServer();
     $userAgent = $request->getUserAgent();
-    
+
     // Get uploaded files
     $files = $request->uploadedFiles();
     $uploadedFile = $files->get('myfile');
@@ -84,7 +104,7 @@ function ($response, $request) {
 | removeSession($var)                               | Remove a value from the session;                        |
 | addCookie($name, $value, $expire, $path, $domain) | Add a cookie;                                           |
 | removeCookie($var)                                | Remove a value from the cookies;                        |
-| getResponseBag()                                  | Returns the ResponseBag object;                         |
+| getResponseBody()                                 | Returns the ResponseBody object;                        |
 | write($object)                                    | See below;                                              |
 | writeDebug($object)                               | Add information to be displayed in case of error;       |
 | emptyResponse()                                   | Empty all previously write responses;                   |
@@ -104,7 +124,7 @@ Example:
 
 ```php
 function ($response, $request) {
-    $response->getResponseBag()->setSerializationRule(SerializationRuleEnum::SingleObject);
+    $response->getResponseBody()->serializeAs(OutputMode::SingleObject);
 
     $myDto = new MyDto();
     
@@ -122,7 +142,7 @@ For example:
 
 ```php
 function ($response, $request) {
-    // Default behavior is SerializationRuleEnum::Automatic
+    // Default behavior is OutputMode::Automatic
     $response->write(['status' => 1]);
     $response->write(['result' => 'ok']);
 }
@@ -140,7 +160,7 @@ Will produce the following output:
 ### Chainning multiple outputs as a single object
 
 We can change the behavior of the output to be a single object
-using the method `getResponseBag()->setSerializationRule(SerializationRuleEnum::SingleObject)`
+using the method `getResponseBody()->serializeAs(OutputMode::SingleObject)`
 
 ```php
 <?php
@@ -150,7 +170,7 @@ using the method `getResponseBag()->setSerializationRule(SerializationRuleEnum::
  * @param \ByJG\RestServer\HttpRequest $request
  */
 function ($response, $request) {
-    $response->getResponseBag()->setSerializationRule(SerializationRuleEnum::SingleObject);
+    $response->getResponseBody()->serializeAs(OutputMode::SingleObject);
     
     // Output an array
     $array = ["field" => "value"];
@@ -191,14 +211,14 @@ The result will be something like:
 }
 ```
 
-### Available serialization rules
+### Available output modes
 
-The ResponseBag supports the following serialization rules:
+The ResponseBody supports the following output modes:
 
-| Enum Value                          | Description                                             |
-|-------------------------------------|---------------------------------------------------------|
-| SerializationRuleEnum::Automatic    | Auto-detect the best format based on inputs             |
-| SerializationRuleEnum::SingleObject | Merge all outputs into a single object                  |
-| SerializationRuleEnum::ObjectList   | Always return the outputs as a list of objects          |
-| SerializationRuleEnum::Raw          | Return the outputs as a raw string (no JSON formatting) |
+| Enum Value               | Description                                             |
+|--------------------------|---------------------------------------------------------|
+| OutputMode::Automatic    | Auto-detect the best format based on inputs             |
+| OutputMode::SingleObject | Merge all outputs into a single object                  |
+| OutputMode::ObjectList   | Always return the outputs as a list of objects          |
+| OutputMode::Plain        | Return the outputs as a plain string (no serialization) |
 

--- a/docs/middleware-jwt.md
+++ b/docs/middleware-jwt.md
@@ -39,20 +39,20 @@ Valid values are:
 - JwtMiddleware::JWT_PARAM_PARSE_STATUS_ERROR
 
 ```php
-$request->param(JwtMiddleware::JWT_PARAM_PARSE_STATUS)
+$request->attribute(JwtMiddleware::JWT_PARAM_PARSE_STATUS)
 ```
 
 #### Return the reason why the token is invalid
 
 ```php
-$request->param(JwtMiddleware::JWT_PARAM_PARSE_MESSAGE)
+$request->attribute(JwtMiddleware::JWT_PARAM_PARSE_MESSAGE)
 ```
 
 #### Return the decoded token
 
 ```php
 // KEY is the key defined in the token
-$request->param(JwtMiddleware::JWT_PARAM_PREFIX . "." . $KEY);
+$request->attribute(JwtMiddleware::JWT_PARAM_PREFIX . "." . $KEY);
 ```
 
 ## Ignoring Paths

--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -4,14 +4,15 @@ sidebar_label: Middleware
 ---
 # Middleware
 
-HttpServerHandler has the ability to inject processing Before and After process the request. Using this you can inject code, change headers
+The `Server` class has the ability to inject processing Before and After the request. Using this you can inject code,
+change headers
 or even block the processing.
 
 You need to implement the class `BeforeMiddlewareInterface` and `AfterMiddlewareInterface` and then add to the handler:
 
 ```php
 <?php
-$httpHandler = new \ByJG\RestServer\HttpRequestHandler();
+$httpHandler = new \ByJG\RestServer\Server();
 $httpHandler
     ->withMiddleware(/*... instance of BeforeMiddlewareInterface or AfterMiddlewareInterface ...*/, /* routing pattern */);
 ```

--- a/docs/mock-testing.md
+++ b/docs/mock-testing.md
@@ -10,14 +10,14 @@ HTTP requests.
 
 ## Mock Request Handler
 
-The `MockRequestHandler` class provides a way to simulate HTTP requests to your API and get back the response that would
+The `MockServer` class provides a way to simulate HTTP requests to your API and get back the response that would
 be generated.
 
 ### Basic Example
 
 ```php
 <?php
-use ByJG\RestServer\MockRequestHandler;
+use ByJG\RestServer\MockServer;
 use ByJG\RestServer\Route\RouteList;
 use Nyholm\Psr7\Request;
 
@@ -33,7 +33,7 @@ $request = new Request(
 );
 
 // Create a mock handler
-$mockHandler = MockRequestHandler::mock($routeDefinition, $request);
+$mockHandler = MockServer::mock($routeDefinition, $request);
 
 // Get the response
 $statusCode = $mockHandler->getPsr7Response()->getStatusCode();
@@ -63,7 +63,7 @@ $mockHttpRequest = new MockHttpRequest($psr7Request, [
 ]);
 
 // Use the mock request for testing
-$id = $mockHttpRequest->param("id"); // Returns 123
+$id = $mockHttpRequest->attribute("id"); // Returns 123
 ```
 
 ## Mock Response
@@ -96,14 +96,14 @@ try {
 
 ## Building reusable test harnesses
 
-Larger test suites benefit from a reusable helper that hides the boilerplate of instantiating `MockRequestHandler` and
+Larger test suites benefit from a reusable helper that hides the boilerplate of instantiating `MockServer` and
 creating PSR-7 requests. The following trait shows one way to structure that helper:
 
 ```php
 <?php
 namespace Tests\Support;
 
-use ByJG\RestServer\MockRequestHandler;
+use ByJG\RestServer\MockServer;
 use ByJG\RestServer\OutputProcessor\JsonOutputProcessor;
 use ByJG\RestServer\Route\Route;
 use ByJG\RestServer\Route\RouteList;
@@ -128,7 +128,7 @@ trait ApiTestTrait
     protected function request(string $method, string $path, array $headers = [], ?string $body = null): ResponseInterface
     {
         $psr7Request = new Request($method, $path, $headers, $body);
-        $handler = new MockRequestHandler();
+        $handler = new MockServer();
         $handler
             ->withDefaultOutputProcessor(JsonOutputProcessor::class)
             ->withRequestObject($psr7Request)

--- a/docs/outprocessor.md
+++ b/docs/outprocessor.md
@@ -24,7 +24,7 @@ The main responsibilities are:
 
 ## How it works
 
-The HttpRequestHandler will call the route and the route will call the OutputProcessor to process the
+The `Server` will call the route and the route will call the OutputProcessor to process the
 proper output for that route.
 
 You can create a route in several ways. e.g.:
@@ -36,14 +36,14 @@ You can create a route in several ways. e.g.:
 
 Each option has its own way to define the OutputProcessor. Check the documentation for each one.
 
-Once you have the route defined, you can initialize the HttpRequestHandler and handle the request.
+Once you have the route defined, you can initialize the `Server` and handle the request.
 
 ```php
 <?php
-use ByJG\RestServer\HttpRequestHandler;
+use ByJG\RestServer\Server;
 use ByJG\RestServer\OutputProcessor\JsonOutputProcessor;
 
-$server = new HttpRequestHandler();
+$server = new Server();
 
 // This is the default processor for the routes that don't have a specific output processor
 $server->withDefaultOutputProcessor(JsonOutputProcessor::class);
@@ -58,7 +58,7 @@ $server->handle($routeList);
 ## Content Negotiation
 
 By default, the OutputProcessor is determined by the route definition or the default processor set in
-HttpRequestHandler.
+`Server`.
 However, the client can request a specific output format using the `Accept` header. The RestServer will use the first
 content type in the Accept header that matches an available OutputProcessor.
 
@@ -303,7 +303,7 @@ class CachedJsonOutputProcessor extends JsonOutputProcessor
         }
     
         // Build the payload the same way JsonOutputProcessor does, so we can store it
-        $serialized = $response->getResponseBag()->process($this->buildNull, $this->onlyString);
+        $serialized = $response->getResponseBody()->process($this->buildNull, $this->onlyString);
         $payload = $this->getFormatter()->process($serialized);
     
         $cacheItem->set($payload);
@@ -323,7 +323,7 @@ class CachedJsonOutputProcessor extends JsonOutputProcessor
         return sprintf(
             'api_response_%d_%s',
             $response->getResponseCode(),
-            md5(serialize($response->getResponseBag()->getCollection()))
+            md5(serialize($response->getResponseBody()->getCollection()))
         );
     }
 }
@@ -350,9 +350,9 @@ The default writer that sends output directly to the HTTP response using PHP's n
 ```php
 <?php
 use ByJG\RestServer\Writer\HttpWriter;
-use ByJG\RestServer\HttpRequestHandler;
+use ByJG\RestServer\Server;
 
-$server = new HttpRequestHandler();
+$server = new Server();
 // HttpWriter is used by default - no need to set explicitly
 ```
 
@@ -370,10 +370,10 @@ methods to retrieve captured data.
 ```php
 <?php
 use ByJG\RestServer\Writer\MemoryWriter;
-use ByJG\RestServer\HttpRequestHandler;
+use ByJG\RestServer\Server;
 
 $writer = new MemoryWriter();
-$server = new HttpRequestHandler();
+$server = new Server();
 $server->withWriter($writer);
 $server->handle($routeDefinition);
 
@@ -403,9 +403,9 @@ Outputs headers and body to stdout (standard output) instead of HTTP. Useful for
 ```php
 <?php
 use ByJG\RestServer\Writer\StdoutWriter;
-use ByJG\RestServer\HttpRequestHandler;
+use ByJG\RestServer\Server;
 
-$server = new HttpRequestHandler();
+$server = new Server();
 $server->withWriter(new StdoutWriter());
 $server->handle($routeDefinition);
 
@@ -425,7 +425,7 @@ $server->handle($routeDefinition);
 
 ### Creating Custom Writers
 
-You can create your own writer by implementing the `WriterInterface` and setting it in the HttpRequestHandler:
+You can create your own writer by implementing the `WriterInterface` and setting it in the `Server`:
 
 ```php
 use ByJG\RestServer\Writer\WriterInterface;

--- a/docs/psr7-adapters.md
+++ b/docs/psr7-adapters.md
@@ -76,7 +76,7 @@ $psr7Response = Psr7ResponseAdapter::fromHttpResponse($httpResponse, 'applicatio
 
 ### Response Body Conversion
 
-The adapter automatically converts the ResponseBag content to a string:
+The adapter automatically converts the ResponseBody content to a string:
 
 - **JSON content**: Encodes data with `JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE`
 - **Single item arrays**: Flattened to the item itself (e.g., `[{...}]` becomes `{...}`)
@@ -115,7 +115,7 @@ Here's a complete example using RestServer with PSR-7 middleware:
 
 ```php
 <?php
-use ByJG\RestServer\HttpRequestHandler;
+use ByJG\RestServer\Server;
 use ByJG\RestServer\HttpResponse;
 use ByJG\RestServer\HttpRequest;
 use ByJG\RestServer\Psr7\Psr7RequestAdapter;
@@ -141,13 +141,13 @@ $routeList->addRoute(
     Route::get('/api/user/{id}')
         ->withClosure(function (HttpResponse $response, HttpRequest $request) {
             // Your route logic
-            $userId = $request->param('id');
+            $userId = $request->attribute('id');
             $response->write(['user_id' => $userId, 'name' => 'John Doe']);
         })
 );
 
 // Create request handler with PSR-7 middleware integration
-$handler = new HttpRequestHandler();
+$handler = new Server();
 $handler->withMiddleware(new class extends \ByJG\RestServer\Middleware\BeforeMiddlewareInterface {
     public function beforeProcess($dispatcherStatus, $response, $request)
     {

--- a/docs/routes-manually.md
+++ b/docs/routes-manually.md
@@ -4,7 +4,7 @@ sidebar_label: Routes Manually
 ---
 # Create Routes Using Classes
 
-> **Note:** For complete setup instructions including HttpRequestHandler configuration, see [Setup](setup.md).
+> **Note:** For complete setup instructions including Server configuration, see [Setup](setup.md).
 
 Creating routes with classes provides better organization, testability, and reusability compared to closures. This
 approach is recommended for production applications with complex business logic.
@@ -93,7 +93,7 @@ class UserController
 {
     public function getUser(HttpResponse $response, HttpRequest $request)
     {
-        $userId = $request->param('id');
+        $userId = $request->attribute('id');
         // Fetch user data...
         $response->write(['user_id' => $userId]);
     }

--- a/docs/routes-using-closures.md
+++ b/docs/routes-using-closures.md
@@ -4,7 +4,7 @@ sidebar_label: Routes using Closures
 ---
 # Creating Routes Using Closures
 
-> **Note:** For complete setup instructions including HttpRequestHandler configuration, see [Setup](setup.md).
+> **Note:** For complete setup instructions including Server configuration, see [Setup](setup.md).
 
 Closures provide a quick and simple way to define routes inline without creating separate classes. They are ideal for
 prototyping, testing, or simple endpoints that don't require complex logic.
@@ -52,7 +52,7 @@ Access route parameters in closures:
 $routeDefinition->addRoute(
     Route::get("/api/user/{id}")
         ->withClosure(function (HttpResponse $response, HttpRequest $request) {
-            $userId = $request->param('id');
+            $userId = $request->attributeString('id');
             $response->write(['user_id' => $userId]);
         })
 );

--- a/docs/routes-using-php-attributes.md
+++ b/docs/routes-using-php-attributes.md
@@ -14,12 +14,12 @@ easier to understand.
 require_once __DIR__ . '/../vendor/autoload.php';
 
 use ByJG\RestServer\Route\RouteList;
-use ByJG\RestServer\HttpRequestHandler;
+use ByJG\RestServer\Server;
 
 $routeDefinition = new RouteList();
 $routeDefinition->addClass(\My\ClassName::class);
 
-$restServer = new HttpRequestHandler();
+$restServer = new Server();
 $restServer->handle($routeDefinition);
 ```
 
@@ -115,7 +115,7 @@ class ValidateUserAccess implements BeforeRouteInterface
     {
         // Implementation to get user roles from request
         // For example, from JWT token
-        return $request->param('jwt.roles') ?? [];
+        return $request->attribute('jwt.roles') ?? [];
     }
 }
 ```
@@ -149,7 +149,7 @@ class LogApiCall implements AfterRouteInterface
             'path' => $request->getRequestPath(),
             'method' => $request->getMethod(),
             'status' => $response->getResponseCode(),
-            'user' => $request->param('jwt.sub') ?? 'anonymous'
+            'user' => $request->attribute('jwt.sub') ?? 'anonymous'
         ]);
     }
 }
@@ -196,7 +196,7 @@ class UserController
     public function getUserProfile(HttpResponse $response, HttpRequest $request)
     {
         // Both users and admins can access profiles
-        $userId = $request->param('jwt.sub');
+        $userId = $request->attribute('jwt.sub');
         $profile = $this->getUserProfile($userId);
         $response->write($profile);
     }
@@ -280,7 +280,7 @@ class SecureController
     public function getProfile(HttpResponse $response, HttpRequest $request)
     {
         // Only authenticated users can access this endpoint
-        $userId = $request->param('jwt.sub');
+        $userId = $request->attribute('jwt.sub');
         $response->write(['user_id' => $userId]);
     }
 }
@@ -332,17 +332,17 @@ class AdminController
 **Examples:**
 
 ```php
-// Basic usage - checks if $request->param('role') === 'admin'
+// Basic usage - checks if $request->attribute('role') === 'admin'
 #[RequireRole('admin')]
 
-// Custom parameter - checks if $request->param('jwt.role') === 'moderator'
+// Custom parameter - checks if $request->attribute('jwt.role') === 'moderator'
 #[RequireRole('moderator', 'jwt.role')]
 
-// Extract from array - if $request->param('user') returns ['role' => 'admin'],
+// Extract from array - if $request->attribute('user') returns ['role' => 'admin'],
 // checks if $user['role'] === 'admin'
 #[RequireRole('admin', 'user', 'role')]
 
-// Extract from object - if $request->param('user') returns object with role property,
+// Extract from object - if $request->attribute('user') returns object with role property,
 // checks if $user->role === 'editor'
 #[RequireRole('editor', 'user', 'role')]
 ```

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -22,7 +22,7 @@ require_once __DIR__ . '/vendor/autoload.php';
 //   4. or auto-generate from an OpenApi definition
 
 // Set up the RestServer
-$restServer = new \ByJG\RestServer\HttpRequestHandler();
+$restServer = new \ByJG\RestServer\Server();
 
 // Optional configurations
 $restServer

--- a/public/app-dist.php
+++ b/public/app-dist.php
@@ -2,12 +2,12 @@
 
 namespace My;
 
-use ByJG\RestServer\HttpRequestHandler;
 use ByJG\RestServer\Middleware\ServerStaticMiddleware;
 use ByJG\RestServer\OutputProcessor\JsonOutputProcessor;
 use ByJG\RestServer\OutputProcessor\XmlOutputProcessor;
 use ByJG\RestServer\Route\Route;
 use ByJG\RestServer\Route\RouteList;
+use ByJG\RestServer\Server;
 
 /**
  * Basic Handler Object
@@ -37,7 +37,7 @@ $routeDefinition->addRoute(Route::get("/testclosure")
 
 $routeDefinition->addRoute(Route::get("/testerror/{code}")
     ->withClosure(function ($response, $request) {
-        $code = $request->param('code');
+        $code = $request->attributeString('code');
         $class = "ByJG\RestServer\Exception\Error" . $code . "Exception";
         throw new $class("Teste");
     })
@@ -62,7 +62,7 @@ $routeDefinition->addRoute(Route::get("/testoverride/json-to-xml")
 );
 
 // Handle Request
-$restServer = new HttpRequestHandler();
+$restServer = new Server();
 $restServer->withDefaultOutputProcessor(JsonOutputProcessor::class);
 // $restServer->withDetailedErrorHandler();
 // $restServer->withCorsOrigins('localhost.*');

--- a/public/app-openapi.php
+++ b/public/app-openapi.php
@@ -1,8 +1,11 @@
 <?php
 
+use ByJG\RestServer\Route\OpenApiRouteList;
+use ByJG\RestServer\Server;
+
 require_once __DIR__ . '/../vendor/autoload.php';
 
-$routeDefinition = new \ByJG\RestServer\Route\OpenApiRouteList(__DIR__ . '/../tests/fixtures/openapi-example.json');
+$routeDefinition = new OpenApiRouteList(__DIR__ . '/../tests/fixtures/openapi-example.json');
 
-$restServer = new \ByJG\RestServer\HttpRequestHandler();
+$restServer = new Server();
 $restServer->handle($routeDefinition);

--- a/public/mock.php
+++ b/public/mock.php
@@ -3,8 +3,9 @@
 namespace My;
 
 use ByJG\RestServer\Exception\Error401Exception;
-use ByJG\RestServer\MockRequestHandler;
+use ByJG\RestServer\MockServer;
 use ByJG\RestServer\OutputProcessor\XmlOutputProcessor;
+use ByJG\RestServer\Route\Route;
 use ByJG\RestServer\Route\RouteList;
 use ByJG\Util\Uri;
 use ByJG\WebRequest\Psr7\Request;
@@ -19,16 +20,16 @@ require_once __DIR__ . '/../vendor/autoload.php';
 // Defining Routes
 $routeDefinition = new RouteList();
 
-$routeDefinition->addRoute(\ByJG\RestServer\Route\Route::get("/testjson")
-    ->withClass(\My\ClassName::class, "someMethod")
+$routeDefinition->addRoute(Route::get("/testjson")
+    ->withClass(ClassName::class, "someMethod")
 );
 
-$routeDefinition->addRoute(\ByJG\RestServer\Route\Route::get("/testxml")
+$routeDefinition->addRoute(Route::get("/testxml")
     ->withOutputProcessor(XmlOutputProcessor::class)
-    ->withClass(\My\ClassName::class, "someMethod")
+    ->withClass(ClassName::class, "someMethod")
 );
 
-$routeDefinition->addRoute(\ByJG\RestServer\Route\Route::get("/testclosure")
+$routeDefinition->addRoute(Route::get("/testclosure")
     ->withClosure(function ($response, $request) {
         $response->write('OK');
         throw new Error401Exception("Bla");
@@ -38,7 +39,7 @@ $routeDefinition->addRoute(\ByJG\RestServer\Route\Route::get("/testclosure")
 $request = Request::getInstance(Uri::getInstanceFromString("http://localhost/testxml"));
 
 // Handle Request
-$mockHandler = MockRequestHandler::mock($routeDefinition, $request);
+$mockHandler = MockServer::mock($routeDefinition, $request);
 
 print_r($mockHandler->getPsr7Response()->getStatusCode());
 echo "\n";

--- a/src/Attributes/RequireAuthenticated.php
+++ b/src/Attributes/RequireAuthenticated.php
@@ -18,8 +18,8 @@ class RequireAuthenticated implements BeforeRouteInterface
     #[Override]
     public function processBefore(HttpResponse $response, HttpRequest $request): void
     {
-        if ($request->param(JwtMiddleware::JWT_PARAM_PARSE_STATUS) !== JwtMiddleware::JWT_SUCCESS) {
-            $message = $request->param(JwtMiddleware::JWT_PARAM_PARSE_MESSAGE) ?? 'Authentication required';
+        if ($request->attribute(JwtMiddleware::JWT_PARAM_PARSE_STATUS) !== JwtMiddleware::JWT_SUCCESS) {
+            $message = $request->attribute(JwtMiddleware::JWT_PARAM_PARSE_MESSAGE) ?? 'Authentication required';
             throw new Error401Exception($message);
         }
     }

--- a/src/Attributes/RequireRole.php
+++ b/src/Attributes/RequireRole.php
@@ -37,13 +37,13 @@ class RequireRole implements BeforeRouteInterface
     public function processBefore(HttpResponse $response, HttpRequest $request): void
     {
         // First check if authenticated
-        if ($request->param(JwtMiddleware::JWT_PARAM_PARSE_STATUS) !== JwtMiddleware::JWT_SUCCESS) {
-            $message = $request->param(JwtMiddleware::JWT_PARAM_PARSE_MESSAGE) ?? 'Authentication required';
+        if ($request->attribute(JwtMiddleware::JWT_PARAM_PARSE_STATUS) !== JwtMiddleware::JWT_SUCCESS) {
+            $message = $request->attribute(JwtMiddleware::JWT_PARAM_PARSE_MESSAGE) ?? 'Authentication required';
             throw new Error401Exception($message);
         }
 
         // Then check the role
-        $userRole = $request->param($this->roleParam);
+        $userRole = $request->attribute($this->roleParam);
 
         // If roleKey is specified and data is an array, extract the value from the array
         if (!empty($userRole) && $this->roleKey !== null) {

--- a/src/Enum/OutputMode.php
+++ b/src/Enum/OutputMode.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace ByJG\RestServer;
+namespace ByJG\RestServer\Enum;
 
-enum SerializationRuleEnum
+enum OutputMode
 {
     case Automatic;
     case SingleObject;
     case ObjectList;
-    case Raw;
+    case Plain;
 }

--- a/src/HttpRequest.php
+++ b/src/HttpRequest.php
@@ -14,15 +14,6 @@ class HttpRequest
     protected array $phpRequest;
     protected array $routeMetadata = [];
 
-    /**
-     *
-     * @param array $get
-     * @param array $post
-     * @param array $server
-     * @param array $session
-     * @param array $cookie
-     * @param array $param
-     */
     public function __construct(array $get, array $post, array $server, array $session, array $cookie, array $param = [])
     {
         $this->get = $get;
@@ -36,10 +27,10 @@ class HttpRequest
     }
 
     /**
-     * Get a parameter passed by GET (the same as $_GET). If not found return false.
-     *
+     * Get a value from the query string ($_GET). Returns all values if $value is null.
+     * Returns $default if the key is not found.
      */
-    public function get(?string $value = null, mixed $default = null): string|array|bool|null
+    public function query(?string $value = null, mixed $default = null): string|array|bool|null
     {
         if (is_null($value)) {
             return $this->get;
@@ -53,10 +44,10 @@ class HttpRequest
     }
 
     /**
-     * Get a parameter passed by POST (the same as $_POST). If not found return false.
-     *
+     * Get a value from the request body ($_POST). Returns all values if $value is null.
+     * Returns $default if the key is not found.
      */
-    public function post(?string $value = null, mixed $default = null): string|array|bool|null
+    public function body(?string $value = null, mixed $default = null): string|array|bool|null
     {
         if (is_null($value)) {
             return $this->post;
@@ -70,8 +61,8 @@ class HttpRequest
     }
 
     /**
-     * Get the parameters sent by server (the same as $_SERVER). If not found return false.
-     *
+     * Get a value from the server parameters ($_SERVER). Returns all values if $value is null.
+     * Returns $default if the key is not found.
      */
     public function server(?string $value = null, mixed $default = null): string|array|bool|null
     {
@@ -87,8 +78,8 @@ class HttpRequest
     }
 
     /**
-     * Get a server session value(the same as $_SESSION). If not found return false.
-     *
+     * Get a value from the session ($_SESSION). Returns all values if $value is null.
+     * Returns $default if the key is not found.
      */
     public function session(?string $value = null, mixed $default = null): string|array|bool|null
     {
@@ -104,8 +95,8 @@ class HttpRequest
     }
 
     /**
-     * Get the cookie sent by the client (the same as $_COOKIE). If not found return false.
-     *
+     * Get a value from the cookies ($_COOKIE). Returns all values if $value is null.
+     * Returns $default if the key is not found.
      */
     public function cookie(?string $value = null, mixed $default = null): string|array|bool|null
     {
@@ -121,10 +112,10 @@ class HttpRequest
     }
 
     /**
-     * Get a value from any of get, post, server, cookie or session. If not found return false.
-     *
+     * Get a value from any source (query, body, server, session, cookie merged).
+     * Returns all values if $value is null. Returns $default if the key is not found.
      */
-    public function request(?string $value = null, mixed $default = null): string|array|bool|null
+    public function input(?string $value = null, mixed $default = null): string|array|bool|null
     {
         if (is_null($value)) {
             return $this->phpRequest;
@@ -138,13 +129,10 @@ class HttpRequest
     }
 
     /**
-     * Get a value from the params found in the URL
-     *
-     * @param ?string $value
-     * @param mixed $default
-     * @return mixed
+     * Get a value injected by middleware or the framework (not URL or HTTP input).
+     * Returns all values if $value is null. Returns $default if the key is not found.
      */
-    public function param(?string $value = null, mixed $default = null): mixed
+    public function attribute(?string $value = null, mixed $default = null): mixed
     {
         if (is_null($value)) {
             return $this->param;
@@ -160,9 +148,7 @@ class HttpRequest
     protected ?string $payload = null;
 
     /**
-     * Get the payload passed during the request(the same as php://input). If not found return empty.
-     *
-     * @return string
+     * Get the raw request body (php://input). Returns an empty string if there is no body.
      */
     public function payload(): string
     {
@@ -175,9 +161,7 @@ class HttpRequest
     }
 
     /**
-     * Use this method to get the CLIENT REQUEST IP.
-     * Note that if you are behind a Proxy, the variable REMOTE_ADDR will always have the same IP
-     * @return string|null
+     * Returns the client IP address, checking common proxy headers before REMOTE_ADDR.
      */
     public function getRequestIp(): ?string
     {
@@ -214,9 +198,6 @@ class HttpRequest
         return $request->getRequestIp();
     }
 
-    /**
-     * @return array|null|string|true
-     */
     public function getUserAgent(): bool|array|string|null
     {
         $userAgent = $this->server('HTTP_USER_AGENT');
@@ -244,10 +225,7 @@ class HttpRequest
     }
 
     /**
-     * Use this method to get the SERVER NAME.
-     * @param bool $port
-     * @param bool $protocol
-     * @return bool|array<array-key, mixed>|string|null
+     * Returns the server name, optionally with port and/or protocol.
      */
     public function getRequestServer(bool $port = false, bool $protocol = false): bool|array|string|null
     {
@@ -275,9 +253,6 @@ class HttpRequest
         return $this->server($header);
     }
 
-    /**
-     * @return bool|array|string|null
-     */
     public function getRequestPath(): bool|array|string|null
     {
         $requestUri = $this->server('REQUEST_URI', "");
@@ -289,9 +264,6 @@ class HttpRequest
 
     private ?UploadedFiles $uploadedFiles = null;
 
-    /**
-     * @return UploadedFiles
-     */
     public function uploadedFiles(): UploadedFiles
     {
         if (is_null($this->uploadedFiles)) {
@@ -300,9 +272,100 @@ class HttpRequest
         return $this->uploadedFiles;
     }
 
-    public function appendVars(array $array): void
+    /** Bulk-add values to the context bag (middleware/framework use). */
+    public function addAttributes(array $array): void
     {
         $this->param = array_merge($this->param, $array);
+    }
+
+    /** Returns the query string value for $key as a string, or $default if not found. */
+    public function queryString(string $key, ?string $default = null): ?string
+    {
+        $value = $this->query($key);
+        if ($value === null || $value === false) {
+            return $default;
+        }
+        return is_array($value) ? implode(',', $value) : (string)$value;
+    }
+
+    /** Returns the query string value for $key as an array, or $default if not found. */
+    public function queryArray(string $key, ?array $default = null): ?array
+    {
+        $value = $this->query($key);
+        if ($value === null || $value === false) {
+            return $default;
+        }
+        return is_array($value) ? $value : [$value];
+    }
+
+    /** Returns the body value for $key as a string, or $default if not found. */
+    public function bodyString(string $key, ?string $default = null): ?string
+    {
+        $value = $this->body($key);
+        if ($value === null || $value === false) {
+            return $default;
+        }
+        return is_array($value) ? implode(',', $value) : (string)$value;
+    }
+
+    /** Returns the body value for $key as an array, or $default if not found. */
+    public function bodyArray(string $key, ?array $default = null): ?array
+    {
+        $value = $this->body($key);
+        if ($value === null || $value === false) {
+            return $default;
+        }
+        return is_array($value) ? $value : [$value];
+    }
+
+    /** Returns the $_SERVER value for $key as a string, or $default if not found. */
+    public function serverString(string $key, ?string $default = null): ?string
+    {
+        $value = $this->server($key);
+        if ($value === null || $value === false) {
+            return $default;
+        }
+        return is_array($value) ? implode(',', $value) : (string)$value;
+    }
+
+    /** Returns the cookie value for $key as a string, or $default if not found. */
+    public function cookieString(string $key, ?string $default = null): ?string
+    {
+        $value = $this->cookie($key);
+        if ($value === null || $value === false) {
+            return $default;
+        }
+        return is_array($value) ? implode(',', $value) : (string)$value;
+    }
+
+    /** Returns the session value for $key as a string, or $default if not found. */
+    public function sessionString(string $key, ?string $default = null): ?string
+    {
+        $value = $this->session($key);
+        if ($value === null || $value === false) {
+            return $default;
+        }
+        return is_array($value) ? implode(',', $value) : (string)$value;
+    }
+
+    /** Returns the context value for $key as a string, or $default if not found. */
+    public function attributeString(string $key, ?string $default = null): ?string
+    {
+        $value = $this->attribute($key);
+        if ($value === null || $value === false) {
+            return $default;
+        }
+        return is_array($value) ? implode(',', $value) : (string)$value;
+    }
+
+    /** Returns the merged input value for $key as a string, or $default if not found. */
+    public function inputString(string $key, ?string $default = null): ?string
+    {
+        $value = $this->input($key);
+        if ($value === null || $value === false) {
+            return $default;
+        }
+        return is_array($value) ? implode(',', $value) : (string)$value;
     }
 
     public function routeMethod(): ?string

--- a/src/HttpResponse.php
+++ b/src/HttpResponse.php
@@ -6,14 +6,14 @@ class HttpResponse
 {
 
     /**
-     * @var ResponseBag
+     * @var ResponseBody
      */
-    protected ResponseBag $response;
+    protected ResponseBody $response;
 
     /**
-     * @var ResponseBag|null
+     * @var ResponseBody|null
      */
-    protected ?ResponseBag $responseDebug = null;
+    protected ?ResponseBody $responseDebug = null;
 
     /**
      * @var array
@@ -81,12 +81,12 @@ class HttpResponse
     }
 
     /**
-     * ResponseBag is a collection of objects will be returned to the  client. RestServer call handle the ResponseBag to
+     * ResponseBody is a collection of objects will be returned to the client. RestServer will handle the ResponseBody to
      * return the proper output. Avoid to use it directly here. Prefer the methods write or writeDebug;
      *
-     * @return ResponseBag
+     * @return ResponseBody
      */
-    public function getResponseBag(): ResponseBag
+    public function getResponseBody(): ResponseBody
     {
         return $this->response;
     }
@@ -112,7 +112,7 @@ class HttpResponse
     {
         // @todo Review this.
         if (is_null($this->responseDebug)) {
-            $this->responseDebug = new ResponseBag();
+            $this->responseDebug = new ResponseBody();
             $this->response->add($this->responseDebug);
         }
         $this->responseDebug->add(['debug' => [$key => $string]]);
@@ -121,7 +121,7 @@ class HttpResponse
 
     public function emptyResponse(): void
     {
-        $this->response = new ResponseBag();
+        $this->response = new ResponseBody();
     }
 
     /**

--- a/src/Middleware/CorsMiddleware.php
+++ b/src/Middleware/CorsMiddleware.php
@@ -2,10 +2,10 @@
 
 namespace ByJG\RestServer\Middleware;
 
+use ByJG\RestServer\Enum\OutputMode;
 use ByJG\RestServer\Exception\Error401Exception;
 use ByJG\RestServer\HttpRequest;
 use ByJG\RestServer\HttpResponse;
-use ByJG\RestServer\SerializationRuleEnum;
 use Override;
 
 class CorsMiddleware implements BeforeMiddlewareInterface
@@ -49,7 +49,7 @@ class CorsMiddleware implements BeforeMiddlewareInterface
         if ($corsStatus != self::CORS_OK) {
             if ($corsStatus == self::CORS_OPTIONS) {
                 $response->emptyResponse();
-                $response->getResponseBag()->setSerializationRule(SerializationRuleEnum::Raw);
+                $response->getResponseBody()->serializeAs(OutputMode::Plain);
                 return MiddlewareResult::stopProcessingOthers;
             } elseif ($corsStatus == self::CORS_FAILED) {
                 throw new Error401Exception("CORS verification failed. Request Blocked.");

--- a/src/Middleware/JwtMiddleware.php
+++ b/src/Middleware/JwtMiddleware.php
@@ -63,7 +63,7 @@ class JwtMiddleware implements BeforeMiddlewareInterface
         } catch (Exception $ex) {
             throw new Error401Exception($ex->getMessage());
         }
-        $request->appendVars($vars);
+        $request->addAttributes($vars);
 
         return MiddlewareResult::continue;
     }

--- a/src/Middleware/ServerStaticMiddleware.php
+++ b/src/Middleware/ServerStaticMiddleware.php
@@ -2,11 +2,11 @@
 
 namespace ByJG\RestServer\Middleware;
 
+use ByJG\RestServer\Enum\OutputMode;
 use ByJG\RestServer\Exception\Error415Exception;
 use ByJG\RestServer\Exception\Error500Exception;
 use ByJG\RestServer\HttpRequest;
 use ByJG\RestServer\HttpResponse;
-use ByJG\RestServer\SerializationRuleEnum;
 use ByJG\RestServer\Util\GeneralUtil;
 use ByJG\Util\Uri;
 use FastRoute\Dispatcher;
@@ -1042,7 +1042,7 @@ class ServerStaticMiddleware implements BeforeMiddlewareInterface
 
             $response->addHeader("Content-Type", $mime);
             $response->emptyResponse();
-            $response->getResponseBag()->setSerializationRule(SerializationRuleEnum::Raw);
+            $response->getResponseBody()->serializeAs(OutputMode::Plain);
             $response->write(file_get_contents($file));
             return MiddlewareResult::stopProcessingOthers;
         }

--- a/src/MockServer.php
+++ b/src/MockServer.php
@@ -19,7 +19,7 @@ use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use RuntimeException;
 
-class MockRequestHandler extends HttpRequestHandler
+class MockServer extends Server
 {
     /**
      * @var RequestInterface|null
@@ -46,7 +46,7 @@ class MockRequestHandler extends HttpRequestHandler
     /**
      * @param RouteListInterface $routes
      * @param RequestInterface $request
-     * @return MockRequestHandler
+     * @return MockServer
      * @throws Error404Exception
      * @throws Error405Exception
      * @throws Error520Exception
@@ -55,7 +55,7 @@ class MockRequestHandler extends HttpRequestHandler
      */
     public static function mock(RouteListInterface $routes, RequestInterface $request)
     {
-        $handler = new MockRequestHandler();
+        $handler = new MockServer();
         $handler->withRequestObject($request);
         $handler->handle($routes);
         return $handler;

--- a/src/OutputProcessor/BaseOutputProcessor.php
+++ b/src/OutputProcessor/BaseOutputProcessor.php
@@ -2,13 +2,13 @@
 
 namespace ByJG\RestServer\OutputProcessor;
 
+use ByJG\RestServer\Enum\OutputMode;
 use ByJG\RestServer\ErrorHandler;
 use ByJG\RestServer\Exception\HttpResponseException;
 use ByJG\RestServer\Exception\OperationIdInvalidException;
 use ByJG\RestServer\Handler\ExceptionFormatter;
 use ByJG\RestServer\HttpRequest;
 use ByJG\RestServer\HttpResponse;
-use ByJG\RestServer\SerializationRuleEnum;
 use ByJG\RestServer\Writer\WriterInterface;
 use Override;
 use Throwable;
@@ -184,10 +184,10 @@ abstract class BaseOutputProcessor implements OutputProcessorInterface
         $this->writeHeader($response);
 
         $serialized = $response
-            ->getResponseBag()
+            ->getResponseBody()
             ->process($this->buildNull, $this->onlyString);
 
-        if ($response->getResponseBag()->getSerializationRule() === SerializationRuleEnum::Raw) {
+        if ($response->getResponseBody()->getOutputMode() === OutputMode::Plain) {
             $this->writeData(is_array($serialized) ? json_encode($serialized) : $serialized);
         } else {
             $this->writeData(

--- a/src/Psr7/Psr7RequestAdapter.php
+++ b/src/Psr7/Psr7RequestAdapter.php
@@ -82,14 +82,14 @@ class Psr7RequestAdapter
         }
 
         // Set query params
-        $getData = $request->get();
+        $getData = $request->query();
         if (is_array($getData) && !empty($getData)) {
             $psr7Request = $psr7Request->withQueryParams($getData);
         }
 
         // Set parsed body (POST data)
         // Note: withParsedBody also updates the body stream, so we need to set Content-Type first
-        $postData = $request->post();
+        $postData = $request->body();
         if (is_array($postData) && !empty($postData)) {
             // Ensure Content-Type header is set for proper encoding
             if (!$psr7Request->hasHeader('Content-Type')) {
@@ -98,8 +98,8 @@ class Psr7RequestAdapter
             $psr7Request = $psr7Request->withParsedBody($postData);
         }
 
-        // Set route params as attributes
-        $params = $request->param();
+        // Set request attributes as PSR-7 attributes
+        $params = $request->attribute();
         if (!empty($params)) {
             foreach ($params as $key => $value) {
                 $psr7Request = $psr7Request->withAttribute($key, $value);

--- a/src/Psr7/Psr7ResponseAdapter.php
+++ b/src/Psr7/Psr7ResponseAdapter.php
@@ -68,8 +68,8 @@ class Psr7ResponseAdapter
             $psr7Response = $psr7Response->withHeader('Content-Type', $contentType);
         }
 
-        // Convert ResponseBag to body
-        $body = self::convertResponseBagToString($response, $contentType);
+        // Convert ResponseBody to body
+        $body = self::convertResponseBodyToString($response, $contentType);
         $stream = new MemoryStream($body);
         return $psr7Response->withBody($stream);
     }
@@ -125,19 +125,19 @@ class Psr7ResponseAdapter
     }
 
     /**
-     * Convert ResponseBag content to string
+     * Convert ResponseBody content to string
      *
      * @param HttpResponse $response
      * @param string $contentType
      * @return string
      */
-    private static function convertResponseBagToString(
+    private static function convertResponseBodyToString(
         HttpResponse $response,
         string       $contentType
     ): string
     {
-        $responseBag = $response->getResponseBag();
-        $collection = $responseBag->getCollection();
+        $responseBody = $response->getResponseBody();
+        $collection = $responseBody->getCollection();
 
         if (empty($collection)) {
             return '';

--- a/src/ResponseBody.php
+++ b/src/ResponseBody.php
@@ -2,28 +2,29 @@
 
 namespace ByJG\RestServer;
 
+use ByJG\RestServer\Enum\OutputMode;
 use ByJG\Serializer\Serialize;
 use InvalidArgumentException;
 
-class ResponseBag
+class ResponseBody
 {
     protected array $collection = [];
-    protected SerializationRuleEnum $serializationRule = SerializationRuleEnum::Automatic;
+    protected OutputMode $outputMode = OutputMode::Automatic;
 
     /**
      * @param string|mixed $object
      */
     public function add(mixed $object): void
     {
-        if (!is_string($object) && !is_numeric($object) && $this->serializationRule === SerializationRuleEnum::Raw) {
-            throw new InvalidArgumentException("Raw data can be only string or numbers");
+        if (!is_string($object) && !is_numeric($object) && $this->outputMode === OutputMode::Plain) {
+            throw new InvalidArgumentException("Plain output mode only accepts strings or numbers");
         }
 
         if (!is_object($object) && !is_array($object)) {
             $object = [ $object ];
         }
 
-        if ($this->serializationRule !== SerializationRuleEnum::SingleObject && $this->serializationRule !== SerializationRuleEnum::Raw) {
+        if ($this->outputMode !== OutputMode::SingleObject && $this->outputMode !== OutputMode::Plain) {
             $this->collection[] = $object;
             return;
         }
@@ -42,12 +43,12 @@ class ResponseBag
     public function process(bool $buildNull = true, bool $onlyString = false): array|string
     {
         $collection = $this->collection;
-        if ($this->serializationRule === SerializationRuleEnum::Raw) {
+        if ($this->outputMode === OutputMode::Plain) {
             return implode("", $collection);
         }
 
         if (count($collection) === 1
-            && $this->serializationRule !== SerializationRuleEnum::ObjectList && isset($collection[0])
+            && $this->outputMode !== OutputMode::ObjectList && isset($collection[0])
         ) {
             $collection = $collection[0];
         }
@@ -69,13 +70,13 @@ class ResponseBag
         return $this->collection;
     }
 
-    public function setSerializationRule(SerializationRuleEnum $value): void
+    public function serializeAs(OutputMode $value): void
     {
-        $this->serializationRule = $value;
+        $this->outputMode = $value;
     }
 
-    public function getSerializationRule(): SerializationRuleEnum
+    public function getOutputMode(): OutputMode
     {
-        return $this->serializationRule;
+        return $this->outputMode;
     }
 }

--- a/src/Server.php
+++ b/src/Server.php
@@ -30,7 +30,7 @@ use Override;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
-class HttpRequestHandler implements RequestHandler
+class Server implements ServerInterface
 {
     const string OK = "OK";
     const string METHOD_NOT_ALLOWED = "NOT_ALLOWED";
@@ -92,7 +92,7 @@ class HttpRequestHandler implements RequestHandler
         $dispatcher = $routeDefinition->getDispatcher();
         $routeInfo = $dispatcher->dispatch($httpMethod, $uri);
         $this->getHttpRequest()->setRouteMetadata($routeInfo[1] ?? []);
-        $this->getHttpRequest()->appendVars(array_merge($routeInfo[2] ?? [], $queryStr));
+        $this->getHttpRequest()->addAttributes(array_merge($routeInfo[2] ?? [], $queryStr));
 
         // Get OutputProcessor
         $outputProcessor = $this->initializeProcessor(

--- a/src/ServerInterface.php
+++ b/src/ServerInterface.php
@@ -7,7 +7,7 @@ use ByJG\RestServer\Middleware\AfterMiddlewareInterface;
 use ByJG\RestServer\Middleware\BeforeMiddlewareInterface;
 use ByJG\RestServer\Route\RouteListInterface;
 
-interface RequestHandler
+interface ServerInterface
 {
     public function handle(RouteListInterface $routeDefinition, bool $outputBuffer = true, bool $session = true);
 

--- a/tests/Attributes/RequireAuthenticatedTest.php
+++ b/tests/Attributes/RequireAuthenticatedTest.php
@@ -5,12 +5,12 @@ namespace Tests\Attributes;
 use ByJG\RestServer\Attributes\RequireAuthenticated;
 use ByJG\RestServer\Exception\Error401Exception;
 use ByJG\RestServer\HttpRequest;
-use ByJG\RestServer\HttpRequestHandler;
 use ByJG\RestServer\HttpResponse;
 use ByJG\RestServer\Middleware\BeforeMiddlewareInterface;
 use ByJG\RestServer\Middleware\JwtMiddleware;
 use ByJG\RestServer\Middleware\MiddlewareResult;
 use ByJG\RestServer\Route\RouteList;
+use ByJG\RestServer\Server;
 use Override;
 use PHPUnit\Framework\TestCase;
 use Tests\MockServerTrait;
@@ -24,7 +24,7 @@ class RequireAuthenticatedTest extends TestCase
     public function setup(): void
     {
         ini_set('output_buffering', 4096);
-        $this->object = new HttpRequestHandler();
+        $this->object = new Server();
         $this->reach = false;
         $this->definition = new RouteList();
 
@@ -85,7 +85,7 @@ class RequireAuthenticatedTest extends TestCase
                 HttpRequest  $request
             ): MiddlewareResult
             {
-                $request->appendVars([
+                $request->addAttributes([
                     JwtMiddleware::JWT_PARAM_PARSE_STATUS => 'failed',
                     JwtMiddleware::JWT_PARAM_PARSE_MESSAGE => 'Invalid token'
                 ]);
@@ -128,7 +128,7 @@ class RequireAuthenticatedTest extends TestCase
                 HttpRequest  $request
             ): MiddlewareResult
             {
-                $request->appendVars([
+                $request->addAttributes([
                     JwtMiddleware::JWT_PARAM_PARSE_STATUS => JwtMiddleware::JWT_SUCCESS
                 ]);
                 return MiddlewareResult::continue;

--- a/tests/Attributes/RequireRoleTest.php
+++ b/tests/Attributes/RequireRoleTest.php
@@ -6,12 +6,12 @@ use ByJG\RestServer\Attributes\RequireRole;
 use ByJG\RestServer\Exception\Error401Exception;
 use ByJG\RestServer\Exception\Error403Exception;
 use ByJG\RestServer\HttpRequest;
-use ByJG\RestServer\HttpRequestHandler;
 use ByJG\RestServer\HttpResponse;
 use ByJG\RestServer\Middleware\BeforeMiddlewareInterface;
 use ByJG\RestServer\Middleware\JwtMiddleware;
 use ByJG\RestServer\Middleware\MiddlewareResult;
 use ByJG\RestServer\Route\RouteList;
+use ByJG\RestServer\Server;
 use Override;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
@@ -26,7 +26,7 @@ class RequireRoleTest extends TestCase
     public function setup(): void
     {
         ini_set('output_buffering', 4096);
-        $this->object = new HttpRequestHandler();
+        $this->object = new Server();
         $this->reach = false;
         $this->definition = new RouteList();
 
@@ -72,7 +72,7 @@ class RequireRoleTest extends TestCase
                 HttpRequest  $request
             ): MiddlewareResult
             {
-                $request->appendVars([
+                $request->addAttributes([
                     JwtMiddleware::JWT_PARAM_PARSE_STATUS => JwtMiddleware::JWT_SUCCESS,
                     'role' => 'user'
                 ]);
@@ -115,7 +115,7 @@ class RequireRoleTest extends TestCase
                 HttpRequest  $request
             ): MiddlewareResult
             {
-                $request->appendVars([
+                $request->addAttributes([
                     JwtMiddleware::JWT_PARAM_PARSE_STATUS => JwtMiddleware::JWT_SUCCESS,
                     'role' => 'admin'
                 ]);
@@ -147,7 +147,7 @@ class RequireRoleTest extends TestCase
                 HttpRequest  $request
             ): MiddlewareResult
             {
-                $request->appendVars([
+                $request->addAttributes([
                     JwtMiddleware::JWT_PARAM_PARSE_STATUS => JwtMiddleware::JWT_SUCCESS,
                     'role' => 'user'
                 ]);
@@ -178,7 +178,7 @@ class RequireRoleTest extends TestCase
                 HttpRequest  $request
             ): MiddlewareResult
             {
-                $request->appendVars([
+                $request->addAttributes([
                     JwtMiddleware::JWT_PARAM_PARSE_STATUS => JwtMiddleware::JWT_SUCCESS,
                     'role' => 'admin'
                 ]);
@@ -221,7 +221,7 @@ class RequireRoleTest extends TestCase
                 HttpRequest  $request
             ): MiddlewareResult
             {
-                $request->appendVars([
+                $request->addAttributes([
                     JwtMiddleware::JWT_PARAM_PARSE_STATUS => JwtMiddleware::JWT_SUCCESS,
                     'role' => 'admin'
                 ]);
@@ -478,7 +478,7 @@ class RequireRoleTest extends TestCase
                 HttpRequest  $request
             ): MiddlewareResult
             {
-                $request->appendVars([
+                $request->addAttributes([
                     JwtMiddleware::JWT_PARAM_PARSE_STATUS => JwtMiddleware::JWT_SUCCESS,
                     'jwt.data' => [
                         'user_id' => 123,
@@ -515,7 +515,7 @@ class RequireRoleTest extends TestCase
                 HttpRequest  $request
             ): MiddlewareResult
             {
-                $request->appendVars([
+                $request->addAttributes([
                     JwtMiddleware::JWT_PARAM_PARSE_STATUS => JwtMiddleware::JWT_SUCCESS,
                     'jwt.data' => [
                         'user_id' => 456,

--- a/tests/HttpRequestHandlerTest.php
+++ b/tests/HttpRequestHandlerTest.php
@@ -3,12 +3,12 @@
 namespace Tests;
 
 use ByJG\RestServer\HttpRequest;
-use ByJG\RestServer\HttpRequestHandler;
 use ByJG\RestServer\HttpResponse;
 use ByJG\RestServer\Middleware\AfterMiddlewareInterface;
 use ByJG\RestServer\Middleware\BeforeMiddlewareInterface;
 use ByJG\RestServer\Middleware\MiddlewareResult;
 use ByJG\RestServer\OutputProcessor\JsonOutputProcessor;
+use ByJG\RestServer\Server;
 use ByJG\RestServer\Writer\MemoryWriter;
 use InvalidArgumentException;
 use Override;
@@ -18,7 +18,7 @@ use stdClass;
 
 class HttpRequestHandlerTest extends TestCase
 {
-    private HttpRequestHandler $handler;
+    private Server $handler;
 
     /**
      * Set up the test environment
@@ -26,7 +26,7 @@ class HttpRequestHandlerTest extends TestCase
     #[Override]
     protected function setUp(): void
     {
-        $this->handler = new HttpRequestHandler();
+        $this->handler = new Server();
     }
 
     /**
@@ -39,7 +39,7 @@ class HttpRequestHandlerTest extends TestCase
         $this->assertSame($this->handler, $result);
 
         // Test that useErrorHandler is set to false
-        $reflectionProperty = new ReflectionProperty(HttpRequestHandler::class, 'useErrorHandler');
+        $reflectionProperty = new ReflectionProperty(Server::class, 'useErrorHandler');
         $this->assertFalse($reflectionProperty->getValue($this->handler));
     }
 
@@ -53,7 +53,7 @@ class HttpRequestHandlerTest extends TestCase
         $this->assertSame($this->handler, $result);
 
         // Test that detailedErrorHandler is set to true
-        $reflectionProperty = new ReflectionProperty(HttpRequestHandler::class, 'detailedErrorHandler');
+        $reflectionProperty = new ReflectionProperty(Server::class, 'detailedErrorHandler');
         $this->assertTrue($reflectionProperty->getValue($this->handler));
     }
 
@@ -67,7 +67,7 @@ class HttpRequestHandlerTest extends TestCase
         $this->assertSame($this->handler, $result);
 
         // Test that defaultOutputProcessor is set correctly
-        $reflectionProperty = new ReflectionProperty(HttpRequestHandler::class, 'defaultOutputProcessor');
+        $reflectionProperty = new ReflectionProperty(Server::class, 'defaultOutputProcessor');
         $this->assertEquals(JsonOutputProcessor::class, $reflectionProperty->getValue($this->handler));
     }
 
@@ -93,7 +93,7 @@ class HttpRequestHandlerTest extends TestCase
         $this->assertSame($this->handler, $result);
 
         // Test that writer is set correctly
-        $reflectionProperty = new ReflectionProperty(HttpRequestHandler::class, 'writer');
+        $reflectionProperty = new ReflectionProperty(Server::class, 'writer');
         $this->assertSame($writer, $reflectionProperty->getValue($this->handler));
     }
 
@@ -110,7 +110,7 @@ class HttpRequestHandlerTest extends TestCase
         $this->assertSame($this->handler, $result);
 
         // Test that middleware is added to beforeMiddlewareList
-        $reflectionProperty = new ReflectionProperty(HttpRequestHandler::class, 'beforeMiddlewareList');
+        $reflectionProperty = new ReflectionProperty(Server::class, 'beforeMiddlewareList');
         $beforeList = $reflectionProperty->getValue($this->handler);
 
         $this->assertCount(1, $beforeList);
@@ -143,7 +143,7 @@ class HttpRequestHandlerTest extends TestCase
         $this->assertSame($this->handler, $result);
 
         // Test that middleware is added to afterMiddlewareList
-        $reflectionProperty = new ReflectionProperty(HttpRequestHandler::class, 'afterMiddlewareList');
+        $reflectionProperty = new ReflectionProperty(Server::class, 'afterMiddlewareList');
         $afterList = $reflectionProperty->getValue($this->handler);
 
         $this->assertCount(1, $afterList);
@@ -186,10 +186,10 @@ class HttpRequestHandlerTest extends TestCase
         $result = $this->handler->withMiddleware($middleware);
 
         // Test that middleware is added to both lists
-        $reflectionBefore = new ReflectionProperty(HttpRequestHandler::class, 'beforeMiddlewareList');
+        $reflectionBefore = new ReflectionProperty(Server::class, 'beforeMiddlewareList');
         $beforeList = $reflectionBefore->getValue($this->handler);
 
-        $reflectionAfter = new ReflectionProperty(HttpRequestHandler::class, 'afterMiddlewareList');
+        $reflectionAfter = new ReflectionProperty(Server::class, 'afterMiddlewareList');
         $afterList = $reflectionAfter->getValue($this->handler);
 
         $this->assertCount(1, $beforeList);

--- a/tests/HttpRequestTest.php
+++ b/tests/HttpRequestTest.php
@@ -64,22 +64,22 @@ class HttpRequestTest extends TestCase
     public function testCookie(): void
     {
         $this->assertEquals(5, $this->request->cookie('cookiep'));
-        $this->assertEquals(5, $this->request->request('cookiep'));
+        $this->assertEquals(5, $this->request->input('cookiep'));
         $this->assertEquals(['cookiep' => 5], $this->request->cookie());
     }
 
     public function testSession(): void
     {
         $this->assertEquals(4, $this->request->session('sessionp'));
-        $this->assertEquals(4, $this->request->request('sessionp'));
+        $this->assertEquals(4, $this->request->input('sessionp'));
         $this->assertEquals(['sessionp' => 4], $this->request->session());
     }
 
     public function testParam(): void
     {
-        $this->assertEquals(6, $this->request->param('paramp'));
-        $this->assertEmpty($this->request->request('paramp'));
-        $this->assertEquals(['paramp' => 6], $this->request->param());
+        $this->assertEquals(6, $this->request->attribute('paramp'));
+        $this->assertEmpty($this->request->input('paramp'));
+        $this->assertEquals(['paramp' => 6], $this->request->attribute());
     }
 
     public function testGetHeader(): void
@@ -94,22 +94,22 @@ class HttpRequestTest extends TestCase
 
     public function testGet(): void
     {
-        $this->assertEquals(1, $this->request->get('getp'));
-        $this->assertEquals(1, $this->request->request('getp'));
-        $this->assertEquals(['getp' => 1], $this->request->get());
+        $this->assertEquals(1, $this->request->query('getp'));
+        $this->assertEquals(1, $this->request->input('getp'));
+        $this->assertEquals(['getp' => 1], $this->request->query());
     }
 
     public function testPost(): void
     {
-        $this->assertEquals(2, $this->request->post('postp'));
-        $this->assertEquals(2, $this->request->request('postp'));
-        $this->assertEquals(['postp' => 2], $this->request->post());
+        $this->assertEquals(2, $this->request->body('postp'));
+        $this->assertEquals(2, $this->request->input('postp'));
+        $this->assertEquals(['postp' => 2], $this->request->body());
     }
 
     public function testAppendVars(): void
     {
-        $this->request->appendVars(['newp' => 7]);
-        $this->assertEquals(7, $this->request->param('newp'));
+        $this->request->addAttributes(['newp' => 7]);
+        $this->assertEquals(7, $this->request->attribute('newp'));
     }
 
     public function testEmptyRequest(): void

--- a/tests/HttpResponseTest.php
+++ b/tests/HttpResponseTest.php
@@ -3,7 +3,7 @@
 namespace Tests;
 
 use ByJG\RestServer\HttpResponse;
-use ByJG\RestServer\ResponseBag;
+use ByJG\RestServer\ResponseBody;
 use Override;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
@@ -159,18 +159,18 @@ class HttpResponseTest extends TestCase
         $this->assertArrayNotHasKey('test_cookie', $_COOKIE);
     }
 
-    public function testResponseBagAndWrite(): void
+    public function testResponseBodyAndWrite(): void
     {
-        // Test getResponseBag
-        $responseBag = $this->object->getResponseBag();
-        $this->assertInstanceOf(ResponseBag::class, $responseBag);
+        // Test getResponseBody
+        $responseBody = $this->object->getResponseBody();
+        $this->assertInstanceOf(ResponseBody::class, $responseBody);
 
         // Test write method
         $testData = ['key' => 'value'];
         $this->object->write($testData);
 
-        // Verify data was added to the response bag
-        $processedData = $responseBag->process();
+        // Verify data was added to the response body
+        $processedData = $responseBody->process();
         $this->assertEquals($testData, $processedData);
 
         // Test writing multiple items
@@ -178,12 +178,12 @@ class HttpResponseTest extends TestCase
         $this->object->write($testData2);
 
         // Verify both items are in the response
-        $processedData = $responseBag->process();
+        $processedData = $responseBody->process();
         $this->assertEquals([$testData, $testData2], $processedData);
 
         // Test emptyResponse
         $this->object->emptyResponse();
-        $processedData = $this->object->getResponseBag()->process();
+        $processedData = $this->object->getResponseBody()->process();
         $this->assertEquals([], $processedData);
     }
 
@@ -195,7 +195,7 @@ class HttpResponseTest extends TestCase
         $this->object->writeDebug($debugKey, $debugValue);
 
         // Get the processed response
-        $processedData = $this->object->getResponseBag()->process();
+        $processedData = $this->object->getResponseBody()->process();
 
         // Verify data was added to the response bag
         $this->assertIsArray($processedData);
@@ -220,7 +220,7 @@ class HttpResponseTest extends TestCase
         $this->object->writeDebug($debugKey2, $debugValue2);
 
         // Get the processed response again
-        $processedData = $this->object->getResponseBag()->process();
+        $processedData = $this->object->getResponseBody()->process();
 
         // Verify both debug entries are present
         $this->assertCount(2, $processedData);

--- a/tests/MockHttpRequestTest.php
+++ b/tests/MockHttpRequestTest.php
@@ -21,7 +21,7 @@ class MockHttpRequestTest extends TestCase
         $psr7Request = RequestMultiPart::build(new Uri("/2?foo=bar"), "POST", $multiPartItems);
         $mockHttpRequest = new MockHttpRequest($psr7Request, ["id" => 2]);
 
-        $this->assertEquals(2, $mockHttpRequest->param("id"));
+        $this->assertEquals(2, $mockHttpRequest->attribute("id"));
 
         $this->assertEquals(
             [

--- a/tests/MockServerTrait.php
+++ b/tests/MockServerTrait.php
@@ -9,7 +9,6 @@ use ByJG\RestServer\Exception\Error405Exception;
 use ByJG\RestServer\Exception\Error520Exception;
 use ByJG\RestServer\Exception\InvalidClassException;
 use ByJG\RestServer\HttpRequest;
-use ByJG\RestServer\HttpRequestHandler;
 use ByJG\RestServer\HttpResponse;
 use ByJG\RestServer\Middleware\AfterMiddlewareInterface;
 use ByJG\RestServer\Middleware\BeforeMiddlewareInterface;
@@ -18,6 +17,7 @@ use ByJG\RestServer\MockResponse;
 use ByJG\RestServer\OutputProcessor\JsonOutputProcessor;
 use ByJG\RestServer\Route\Route;
 use ByJG\RestServer\Route\RouteList;
+use ByJG\RestServer\Server;
 use ByJG\RestServer\Writer\MemoryWriter;
 use ByJG\Util\Uri;
 use Exception;
@@ -27,9 +27,9 @@ use Monolog\Logger;
 trait MockServerTrait
 {
     /**
-     * @var HttpRequestHandler|null
+     * @var Server|null
      */
-    protected ?HttpRequestHandler $object;
+    protected ?Server $object;
 
     /**
      * @var RouteList
@@ -47,7 +47,7 @@ trait MockServerTrait
         $logger = new Logger("unittest");
         $stream_handler = new StreamHandler("php://stderr");
         $logger->pushHandler($stream_handler);
-        $this->object = new HttpRequestHandler($logger);
+        $this->object = new Server($logger);
 
         $this->reach = false;
 
@@ -79,8 +79,8 @@ trait MockServerTrait
                 ->withClosure(function ($response, $request) {
                     $this->assertInstanceOf(HttpResponse::class, $response);
                     $this->assertInstanceOf(HttpRequest::class, $request);
-                    $this->reach = $request->param('id');
-                    $response->write(["key" => $request->param('id')]);
+                    $this->reach = $request->attributeString('id');
+                    $response->write(["key" => $request->attributeString('id')]);
                 })
         );
 
@@ -89,7 +89,7 @@ trait MockServerTrait
                 ->withClosure(function ($response, $request) {
                     $this->assertInstanceOf(HttpResponse::class, $response);
                     $this->assertInstanceOf(HttpRequest::class, $request);
-                    $this->reach = $request->param('id');
+                    $this->reach = $request->attributeString('id');
                     $response->write("Success!");
                 })
         );
@@ -99,9 +99,9 @@ trait MockServerTrait
                 ->withClosure(function ($response, $request) {
                     $response->write(
                         [
-                            JwtMiddleware::JWT_PARAM_PARSE_STATUS => $request->param(JwtMiddleware::JWT_PARAM_PARSE_STATUS),
-                            JwtMiddleware::JWT_PARAM_PARSE_MESSAGE => $request->param(JwtMiddleware::JWT_PARAM_PARSE_MESSAGE),
-                            JwtMiddleware::JWT_PARAM_PREFIX . ".userid" => $request->param(JwtMiddleware::JWT_PARAM_PREFIX . ".userid")
+                            JwtMiddleware::JWT_PARAM_PARSE_STATUS => $request->attribute(JwtMiddleware::JWT_PARAM_PARSE_STATUS),
+                            JwtMiddleware::JWT_PARAM_PARSE_MESSAGE => $request->attribute(JwtMiddleware::JWT_PARAM_PARSE_MESSAGE),
+                            JwtMiddleware::JWT_PARAM_PREFIX . ".userid" => $request->attribute(JwtMiddleware::JWT_PARAM_PREFIX . ".userid")
                         ]
                     );
                 })
@@ -130,7 +130,7 @@ trait MockServerTrait
     }
 
     /**
-     * @param HttpRequestHandler $handler
+     * @param Server $handler
      * @param array|null $expectedHeader
      * @param mixed $expectedData
      * @param AfterMiddlewareInterface|BeforeMiddlewareInterface|null $middleWare
@@ -141,7 +141,7 @@ trait MockServerTrait
      * @throws Error520Exception
      * @throws InvalidClassException
      */
-    public function processAndGetContent(HttpRequestHandler $handler, ?array $expectedHeader, mixed $expectedData, AfterMiddlewareInterface|BeforeMiddlewareInterface|null $middleWare = null, array $expectedParams = []): void
+    public function processAndGetContent(Server $handler, ?array $expectedHeader, mixed $expectedData, AfterMiddlewareInterface|BeforeMiddlewareInterface|null $middleWare = null, array $expectedParams = []): void
     {
         $writer = new MemoryWriter();
 

--- a/tests/Psr7/Psr7ResponseAdapterTest.php
+++ b/tests/Psr7/Psr7ResponseAdapterTest.php
@@ -156,8 +156,8 @@ class Psr7ResponseAdapterTest extends TestCase
 
         $httpResponse = Psr7ResponseAdapter::toHttpResponse($psr7Response);
 
-        $responseBag = $httpResponse->getResponseBag();
-        $collection = $responseBag->getCollection();
+        $responseBody = $httpResponse->getResponseBody();
+        $collection = $responseBody->getCollection();
 
         $this->assertNotEmpty($collection);
         $this->assertEquals($data, $collection[0]);
@@ -173,11 +173,11 @@ class Psr7ResponseAdapterTest extends TestCase
 
         $httpResponse = Psr7ResponseAdapter::toHttpResponse($psr7Response);
 
-        $responseBag = $httpResponse->getResponseBag();
-        $collection = $responseBag->getCollection();
+        $responseBody = $httpResponse->getResponseBody();
+        $collection = $responseBody->getCollection();
 
         $this->assertNotEmpty($collection);
-        // When writing a string to ResponseBag, it wraps it in an array
+        // When writing a string to ResponseBody, it wraps it in an array
         $this->assertEquals(['Plain text response'], $collection[0]);
     }
 
@@ -222,7 +222,7 @@ class Psr7ResponseAdapterTest extends TestCase
         $headers = $convertedResponse->getHeaders();
         $this->assertArrayHasKey('x-test', $headers);
 
-        $collection = $convertedResponse->getResponseBag()->getCollection();
+        $collection = $convertedResponse->getResponseBody()->getCollection();
         $this->assertEquals(['message' => 'Hello World'], $collection[0]);
     }
 

--- a/tests/ResponseBodyTest.php
+++ b/tests/ResponseBodyTest.php
@@ -2,26 +2,28 @@
 
 namespace Tests;
 
-use ByJG\RestServer\ResponseBag;
-use ByJG\RestServer\SerializationRuleEnum;
+use ByJG\RestServer\Enum\OutputMode;
+use ByJG\RestServer\ResponseBody;
 use InvalidArgumentException;
+use Override;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 use Tests\Model\ModelSample;
 
-class ResponseBagTest extends TestCase
+class ResponseBodyTest extends TestCase
 {
     /**
-     * @var ResponseBag
+     * @var ResponseBody
      */
     private $object;
 
-    #[\Override]
+    #[Override]
     public function setup(): void
     {
-        $this->object = new ResponseBag();
+        $this->object = new ResponseBody();
     }
 
-    #[\Override]
+    #[Override]
     public function tearDown(): void
     {
         $this->object = null;
@@ -47,7 +49,7 @@ class ResponseBagTest extends TestCase
 
     public function testAddStringArray(): void
     {
-        $this->object->setSerializationRule(SerializationRuleEnum::ObjectList);
+        $this->object->serializeAs(OutputMode::ObjectList);
         $this->object->add('Test1');
         $this->assertEquals(
             [
@@ -68,7 +70,7 @@ class ResponseBagTest extends TestCase
 
     public function testAddStringSingleObject(): void
     {
-        $this->object->setSerializationRule(SerializationRuleEnum::SingleObject);
+        $this->object->serializeAs(OutputMode::SingleObject);
         $this->object->add('Test1');
         $this->assertEquals(
             'Test1',
@@ -105,7 +107,7 @@ class ResponseBagTest extends TestCase
 
     public function testAddArrayArray(): void
     {
-        $this->object->setSerializationRule(SerializationRuleEnum::ObjectList);
+        $this->object->serializeAs(OutputMode::ObjectList);
         $this->object->add(['key1' => 'Test1']);
         $this->assertEquals(
             [
@@ -126,7 +128,7 @@ class ResponseBagTest extends TestCase
 
     public function testAddArraySingleObject(): void
     {
-        $this->object->setSerializationRule(SerializationRuleEnum::SingleObject);
+        $this->object->serializeAs(OutputMode::SingleObject);
         $this->object->add(['key1' => 'Test1']);
         $this->assertEquals(
             ['key1' => 'Test1'],
@@ -145,7 +147,7 @@ class ResponseBagTest extends TestCase
 
     public function testAddObjectAutomatic(): void
     {
-        $obj1 = new \stdClass();
+        $obj1 = new stdClass();
         $obj1->MyField = [ "teste1" => "value1", "test2" => [ "3", "4"]];
         $obj1->OtherField = "OK";
 
@@ -178,13 +180,13 @@ class ResponseBagTest extends TestCase
 
     public function testAddObjectArray(): void
     {
-        $obj1 = new \stdClass();
+        $obj1 = new stdClass();
         $obj1->MyField = [ "teste1" => "value1", "test2" => [ "3", "4"]];
         $obj1->OtherField = "OK";
 
         $obj2 = new ModelSample('value3', 'value4');
 
-        $this->object->setSerializationRule(SerializationRuleEnum::ObjectList);
+        $this->object->serializeAs(OutputMode::ObjectList);
         $this->object->add($obj1);
         $this->assertEquals(
             [
@@ -214,13 +216,13 @@ class ResponseBagTest extends TestCase
 
     public function testAddObjectSingleObject(): void
     {
-        $obj1 = new \stdClass();
+        $obj1 = new stdClass();
         $obj1->MyField = [ "teste1" => "value1", "test2" => [ "3", "4"]];
         $obj1->OtherField = "OK";
 
         $obj2 = new ModelSample('value3', 'value4');
 
-        $this->object->setSerializationRule(SerializationRuleEnum::SingleObject);
+        $this->object->serializeAs(OutputMode::SingleObject);
         $this->object->add($obj1);
         $this->assertEquals(
             [
@@ -249,7 +251,7 @@ class ResponseBagTest extends TestCase
 
     public function testRaw(): void
     {
-        $this->object->setSerializationRule(SerializationRuleEnum::Raw);
+        $this->object->serializeAs(OutputMode::Plain);
         $this->object->add('Test1');
         $this->assertEquals(
             'Test1',
@@ -266,7 +268,7 @@ class ResponseBagTest extends TestCase
     public function testRawInvalid(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->object->setSerializationRule(SerializationRuleEnum::Raw);
+        $this->object->serializeAs(OutputMode::Plain);
         $this->object->add(['Test1']);
     }
 }

--- a/tests/ServerHandlerAttributeTest.php
+++ b/tests/ServerHandlerAttributeTest.php
@@ -2,8 +2,9 @@
 
 namespace Tests;
 
-use ByJG\RestServer\HttpRequestHandler;
 use ByJG\RestServer\Route\RouteList;
+use ByJG\RestServer\Server;
+use Override;
 use PHPUnit\Framework\TestCase;
 use Tests\Routes\RouteFromAttributes;
 
@@ -11,11 +12,11 @@ class ServerHandlerAttributeTest extends TestCase
 {
     use MockServerTrait;
 
-    #[\Override]
+    #[Override]
     public function setup(): void
     {
         ini_set('output_buffering', 4096);
-        $this->object = new HttpRequestHandler();
+        $this->object = new Server();
         $this->reach = false;
         $this->definition = new RouteList();
 


### PR DESCRIPTION
---

### Summary

This pull request refactors key areas of the codebase to enhance consistency and clarity across request handling, enums, and class naming.

### Changes

- Standardized `HttpRequest` methods, replacing ambiguous terms (`param` → `attribute`, `request` → `input`) to better distinguish data sources.
- Merged `ResponseBag` methods into `ResponseBody` and introduced enhanced serialization modes (`Plain`, `SingleObject`, etc.).
- Replaced `SerializationRuleEnum` with a streamlined `OutputMode` enumeration and updated related references.
- Renamed `HttpRequestHandler` to `Server` for a clearer, more accurate class name.
- Updated related tests to reflect the refactored methods, enums, and naming conventions.

### Checklist

- [ ] All tests are passing.
- [ ] Relevant documentation